### PR TITLE
Allow joystick disconnection and reconnection instead of going into exception

### DIFF
--- a/controldev.orogen
+++ b/controldev.orogen
@@ -27,6 +27,8 @@ end
 task_context "JoystickTask", subclasses: 'GenericTask' do
     default_activity :fd_driven
 
+    runtime_states "CONNECTED", "NOT_CONNECTED"
+
     # Path to the joystick device
     property "device", "/std/string", "/dev/input/js0"
 end

--- a/tasks/GenericTask.cpp
+++ b/tasks/GenericTask.cpp
@@ -17,7 +17,6 @@ GenericTask::~GenericTask()
 
 bool GenericTask::configureHook()
 {
-    std::cout << "configureHook from GenericTask" << std::endl;
     axisHandles.clear();
     
     const std::vector<AxisPort> &portDescs(_axisPorts.get());
@@ -54,24 +53,24 @@ bool GenericTask::startHook()
 void GenericTask::updateHook()
 {
     GenericTaskBase::updateHook();
-    
+
     RawCommand rcmd;
     updateRawCommand(rcmd);
-    
+
     if(axisScales.size() > rcmd.axisValue.size())
     {
         std::cout << "Error, more scale factors than axes defined : Nr axes " << rcmd.axisValue.size() << " size of axis scales " << axisScales.size() << std::endl;
         exception();
     }
-    
+
     RawCommand rscaled = rcmd;
     for(size_t i = 0 ; i < axisScales.size(); i++)
     {
         rscaled.axisValue[i] *= axisScales[i];
     }
-    
+
     _raw_command.write(rscaled);
-    
+
     for(size_t i = 0 ; i < axisHandles.size(); i++)
     {
         const AxisPortHandle &handle(axisHandles[i]);

--- a/tasks/GenericTask.cpp
+++ b/tasks/GenericTask.cpp
@@ -39,15 +39,13 @@ bool GenericTask::configureHook()
 
 bool GenericTask::startHook()
 {
-    std::cout << "startHook from GenericTask" << std::endl;
     RTT::extras::FileDescriptorActivity* activity =
         getActivity<RTT::extras::FileDescriptorActivity>();
     if (activity)
     {
         activity->watch(getFileDescriptor());
         //get trigger a least every 25 ms
-//        activity->setTimeout(25);
-        activity->setTimeout(1000);
+        activity->setTimeout(25);
     }
 
     return TaskContext::startHook();

--- a/tasks/GenericTask.cpp
+++ b/tasks/GenericTask.cpp
@@ -17,6 +17,7 @@ GenericTask::~GenericTask()
 
 bool GenericTask::configureHook()
 {
+    std::cout << "configureHook from GenericTask" << std::endl;
     axisHandles.clear();
     
     const std::vector<AxisPort> &portDescs(_axisPorts.get());
@@ -38,13 +39,15 @@ bool GenericTask::configureHook()
 
 bool GenericTask::startHook()
 {
+    std::cout << "startHook from GenericTask" << std::endl;
     RTT::extras::FileDescriptorActivity* activity =
         getActivity<RTT::extras::FileDescriptorActivity>();
     if (activity)
     {
         activity->watch(getFileDescriptor());
         //get trigger a least every 25 ms
-        activity->setTimeout(25);
+//        activity->setTimeout(25);
+        activity->setTimeout(1000);
     }
 
     return TaskContext::startHook();
@@ -54,10 +57,9 @@ void GenericTask::updateHook()
 {
     GenericTaskBase::updateHook();
     
-     
     RawCommand rcmd;
     updateRawCommand(rcmd);
-
+    
     if(axisScales.size() > rcmd.axisValue.size())
     {
         std::cout << "Error, more scale factors than axes defined : Nr axes " << rcmd.axisValue.size() << " size of axis scales " << axisScales.size() << std::endl;
@@ -71,7 +73,7 @@ void GenericTask::updateHook()
     }
     
     _raw_command.write(rscaled);
-
+    
     for(size_t i = 0 ; i < axisHandles.size(); i++)
     {
         const AxisPortHandle &handle(axisHandles[i]);
@@ -95,4 +97,3 @@ void GenericTask::stopHook()
     if(activity)
         activity->clearAllWatches();
 }
-

--- a/tasks/GenericTask.hpp
+++ b/tasks/GenericTask.hpp
@@ -8,12 +8,12 @@
 namespace controldev {
     class GenericTask : public GenericTaskBase
     {
-	friend class GenericTaskBase;
+    friend class GenericTaskBase;
     protected:
         virtual bool updateRawCommand(RawCommand& rcmd) = 0;
 
         virtual int getFileDescriptor() = 0;
-        
+    
         class AxisPortHandle
         {
         public:
@@ -23,11 +23,12 @@ namespace controldev {
         
         std::vector<AxisPortHandle> axisHandles;
         std::vector<double> axisScales;
+
     public:
         GenericTask(std::string const& name = "controldev::GenericTask");
         GenericTask(std::string const& name, RTT::ExecutionEngine* engine);
 
-	virtual ~GenericTask();
+        virtual ~GenericTask();
 
         /** This hook is called by Orocos when the state machine transitions
          * from PreOperational to Stopped. If it returns false, then the
@@ -89,9 +90,6 @@ namespace controldev {
          * before calling start() again.
          */
         // void cleanupHook();
-
-        
-
 
     };
 }

--- a/tasks/GenericTask.hpp
+++ b/tasks/GenericTask.hpp
@@ -8,12 +8,12 @@
 namespace controldev {
     class GenericTask : public GenericTaskBase
     {
-    friend class GenericTaskBase;
+        friend class GenericTaskBase;
     protected:
         virtual bool updateRawCommand(RawCommand& rcmd) = 0;
 
         virtual int getFileDescriptor() = 0;
-    
+
         class AxisPortHandle
         {
         public:

--- a/tasks/JoystickTask.cpp
+++ b/tasks/JoystickTask.cpp
@@ -7,12 +7,12 @@
 using namespace controldev;
 
 JoystickTask::JoystickTask(std::string const& name)
-    : JoystickTaskBase(name), joystick(new controldev::Joystick())
+    : JoystickTaskBase(name), joystick(new controldev::Joystick()), device_connected_(false)
 {
 }
 
 JoystickTask::JoystickTask(std::string const& name, RTT::ExecutionEngine* engine)
-    : JoystickTaskBase(name, engine), joystick(new controldev::Joystick())
+    : JoystickTaskBase(name, engine), joystick(new controldev::Joystick()), device_connected_(false)
 {
 }
 
@@ -29,21 +29,25 @@ bool JoystickTask::configureHook()
 {
     if (! JoystickTaskBase::configureHook())
         return false;
-    
-    // Try to connect the Joystick
-    if (!joystick->init(_device.value()))
-    {
-        std::cerr << "Warning: Unable to open Joystick device "
-            << _device.value() << std::endl;
-	return false;
-    }
+
+    connectDevice();
 
     return true;
 }
 
 int JoystickTask::getFileDescriptor()
 {
+//    int i;
+//    try
+//    {
+//        i = joystick->getFileDescriptor();
+//    } catch (const std::exception & e) {
+//        std::cerr << "ERROR caught myself! " << std::endl;
+//        std::cerr << "ERROR caught: " << e.what() << std::endl;
+//    }
     return joystick->getFileDescriptor();
+//    return i;
+
 }
 
 bool JoystickTask::updateRawCommand(RawCommand& rcmd) {
@@ -51,17 +55,27 @@ bool JoystickTask::updateRawCommand(RawCommand& rcmd) {
     while(joystick->updateState())
     {
     }
-    
+
     rcmd.deviceIdentifier= joystick->getName();
     
     rcmd.axisValue = joystick->getAxes();
     
     size_t buttonCount = joystick->getNrButtons();
 
-    // Set button bit list
-    for (size_t i = 0; i < buttonCount; i++)
+    try
     {
-        rcmd.buttonValue.push_back(joystick->getButtonPressed(i));
+        // Set button bit list
+        for (size_t i = 0; i < buttonCount; i++)
+        {
+            rcmd.buttonValue.push_back(joystick->getButtonPressed(i));
+        }
+    } catch (const std::runtime_error& e) {
+        std::cerr << "Warning: Caught runtime error. Lost connection to device." << std::endl;
+        delete joystick;
+        joystick = new controldev::Joystick();
+        device_connected_ = false;
+        state(NOT_CONNECTED);
+        return false;
     }
     
     rcmd.time = base::Time::now();
@@ -72,10 +86,37 @@ bool JoystickTask::updateRawCommand(RawCommand& rcmd) {
 
 void JoystickTask::updateHook()
 {
-    JoystickTaskBase::updateHook();
-     
-    RawCommand rcmd;
-    updateRawCommand(rcmd);
-    _raw_command.write(rcmd);
+    std::cout << "DEBUG: in updateHook: " << __LINE__ << std::endl;
+    if (device_connected_)
+    {
+        state(CONNECTED);
+        JoystickTaskBase::updateHook();
+
+        RawCommand rcmd;
+        updateRawCommand(rcmd);
+        _raw_command.write(rcmd);
+    } else {
+        state(NOT_CONNECTED);
+        connectDevice();
+    }
 }
 
+bool JoystickTask::connectDevice()
+{
+    // Try to connect the Joystick
+    std::cout << "DEBUG: in connectDevice: " << __LINE__ << std::endl;
+    if (joystick->init(_device.value()))
+    {
+        device_connected_ = true;
+        std::cout << "INFO: Device " << _device.value() << " connected" << std::endl;
+        return true;
+    } else {
+        if (device_connected_)
+        {
+            std::cerr << "Warning: Unable to open Joystick device "
+                << _device.value() << std::endl;
+        }
+        device_connected_ = false;
+        return false;
+    }
+}

--- a/tasks/JoystickTask.hpp
+++ b/tasks/JoystickTask.hpp
@@ -13,9 +13,13 @@ namespace controldev {
 	friend class JoystickTaskBase;
     protected:
         Joystick *joystick;
+        bool device_connected_;
 
-        virtual bool updateRawCommand(RawCommand& rcmd);
-        virtual int getFileDescriptor();
+
+        virtual bool updateRawCommand(RawCommand& rcmd) override;
+        virtual int getFileDescriptor() override;
+        bool connectDevice();
+
     public:
         JoystickTask(std::string const& name = "controldev::JoystickTask");
         JoystickTask(std::string const& name, RTT::ExecutionEngine* engine);

--- a/tasks/JoystickTask.hpp
+++ b/tasks/JoystickTask.hpp
@@ -26,7 +26,7 @@ namespace controldev {
         JoystickTask(std::string const& name = "controldev::JoystickTask");
         JoystickTask(std::string const& name, RTT::ExecutionEngine* engine);
 
-    	~JoystickTask();
+        ~JoystickTask();
 
         /** This hook is called by Orocos when the state machine transitions
          * from PreOperational to Stopped. If it returns false, then the

--- a/tasks/JoystickTask.hpp
+++ b/tasks/JoystickTask.hpp
@@ -15,16 +15,18 @@ namespace controldev {
         Joystick *joystick;
         bool device_connected_;
 
-
-        virtual bool updateRawCommand(RawCommand& rcmd) override;
         virtual int getFileDescriptor() override;
-        bool connectDevice();
+        virtual bool updateRawCommand(RawCommand& rcmd) override;
+        void connectDevice(bool recover = false);
+        bool recoverConnection();
+        void writeCommand();
+        bool checkAxisValues(const RawCommand& rcmd);
 
     public:
         JoystickTask(std::string const& name = "controldev::JoystickTask");
         JoystickTask(std::string const& name, RTT::ExecutionEngine* engine);
 
-	~JoystickTask();
+    	~JoystickTask();
 
         /** This hook is called by Orocos when the state machine transitions
          * from PreOperational to Stopped. If it returns false, then the


### PR DESCRIPTION
This code is functional and has been tested in the field. I expect that the following two points should be addressed before merging. However, before putting more effort into it, I wanted to open this MR to gather some feedback.

- [ ] replace the raw pointer with unique pointer
- [ ] make this behaviour optional (e.g. property allow_disconnect) and set it to false by default to not break anything